### PR TITLE
fix: remove stray text from styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -831,4 +831,3 @@ html, body {
         right: 10px;
     }
 }
-t and show main content


### PR DESCRIPTION
## Summary
- fix CSS syntax error by removing stray text at end of styles.css

## Testing
- None

------
https://chatgpt.com/codex/tasks/task_b_689f099965b88322a6d77aa133ed6903