### PR TITLE
Remove dead generator and community navigation links

### DIFF
--- a/idea_detail.html
+++ b/idea_detail.html
@@ -17,11 +17,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="index.html">Home</a>
-        <a href="generator.html">Generator</a>
         <a href="ideas.html">My Ideas</a>
         <a href="trending.html">Trending</a>
         <a href="resources.html">Resources</a>
-        <a href="community.html">Community</a>
         <a href="legal/terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/ideas.html
+++ b/ideas.html
@@ -17,11 +17,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="index.html">Home</a>
-        <a href="generator.html">Generator</a>
         <a href="ideas.html">My Ideas</a>
         <a href="trending.html">Trending</a>
         <a href="resources.html">Resources</a>
-        <a href="community.html">Community</a>
         <a href="legal/terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/index.html
+++ b/index.html
@@ -22,11 +22,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="index.html">Home</a>
-        <a href="generator.html">Generator</a>
         <a href="ideas.html">My Ideas</a>
         <a href="trending.html">Trending</a>
         <a href="resources.html">Resources</a>
-        <a href="community.html">Community</a>
         <a href="legal/terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/legal/disclaimer.html
+++ b/legal/disclaimer.html
@@ -17,11 +17,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="../index.html">Home</a>
-        <a href="../generator.html">Generator</a>
         <a href="../ideas.html">My Ideas</a>
         <a href="../trending.html">Trending</a>
         <a href="../resources.html">Resources</a>
-        <a href="../community.html">Community</a>
         <a href="terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -17,11 +17,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="../index.html">Home</a>
-        <a href="../generator.html">Generator</a>
         <a href="../ideas.html">My Ideas</a>
         <a href="../trending.html">Trending</a>
         <a href="../resources.html">Resources</a>
-        <a href="../community.html">Community</a>
         <a href="terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/legal/terms.html
+++ b/legal/terms.html
@@ -21,11 +21,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="../index.html">Home</a>
-        <a href="../generator.html">Generator</a>
         <a href="../ideas.html">My Ideas</a>
         <a href="../trending.html">Trending</a>
         <a href="../resources.html">Resources</a>
-        <a href="../community.html">Community</a>
         <a href="terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/resources.html
+++ b/resources.html
@@ -17,11 +17,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="index.html">Home</a>
-        <a href="generator.html">Generator</a>
         <a href="ideas.html">My Ideas</a>
         <a href="trending.html">Trending</a>
         <a href="resources.html">Resources</a>
-        <a href="community.html">Community</a>
         <a href="legal/terms.html">Legal</a>
       </nav>
       <div class="header-actions">

--- a/trending.html
+++ b/trending.html
@@ -17,11 +17,9 @@
       <button id="mobile-menu-toggle" class="mobile-menu-toggle" aria-label="Open menu">☰</button>
       <nav class="nav">
         <a href="index.html">Home</a>
-        <a href="generator.html">Generator</a>
         <a href="ideas.html">My Ideas</a>
         <a href="trending.html">Trending</a>
         <a href="resources.html">Resources</a>
-        <a href="community.html">Community</a>
         <a href="legal/terms.html">Legal</a>
       </nav>
       <div class="header-actions">


### PR DESCRIPTION
## Summary
- drop Generator and Community links from the navigation bar on every page

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_689f43351db483229ffce99395c24afd